### PR TITLE
Merge apply_staked_claim into apply_eos_claim

### DIFF
--- a/libraries/native_contract/eos_contract.cpp
+++ b/libraries/native_contract/eos_contract.cpp
@@ -94,21 +94,6 @@ void apply_eos_newaccount(apply_context& context) {
 }
 
 /**
- *  This method is called when the claim message is delivered to @staked 
- *  staked::validate_staked_claim must require that @eos be notified.
- *
- *  This method trusts that staked::precondition_staked_claim verifies that claim.amount is
- *  available.
- */
-void apply_staked_claim(apply_context& context) {
-   auto claim = context.msg.as<types::claim>();
-   const auto& claimant = context.db.get<BalanceObject, byOwnerName>(claim.account);
-   context.mutable_db.modify(claimant, [&claim](BalanceObject& a) {
-      a.balance += claim.amount;
-   });
-}
-
-/**
  *
  * @ingroup native_eos
  * @defgroup eos_eos_transfer eos::eos_transfer
@@ -228,16 +213,19 @@ void apply_eos_claim(apply_context& context) {
    EOS_ASSERT(balance != nullptr, message_precondition_exception,
               "Could not find staked balance for ${name}", ("name", claim.account));
    auto balanceReleaseTime = balance->lastUnstakingTime + config::StakedBalanceCooldownSeconds;
-   auto now = context.db.get(dynamic_global_property_object::id_type()).time;
+   auto now = context.controller.head_block_time();
    EOS_ASSERT(now >= balanceReleaseTime, message_precondition_exception,
               "Cannot claim balance until ${releaseDate}", ("releaseDate", balanceReleaseTime));
    EOS_ASSERT(balance->unstakingBalance >= claim.amount, message_precondition_exception,
               "Cannot claim ${claimAmount} as only ${available} is available for claim",
               ("claimAmount", claim.amount)("available", balance->unstakingBalance));
 
-   context.mutable_db.modify(context.db.get<StakedBalanceObject, byOwnerName>(claim.account),
-                             [&claim](StakedBalanceObject& sbo) {
-      sbo.unstakingBalance -= claim.amount;
+   const auto& stakedBalance = context.db.get<StakedBalanceObject, byOwnerName>(claim.account);
+   stakedBalance.finishUnstakingTokens(claim.amount, context.mutable_db);
+
+   const auto& liquidBalance = context.db.get<BalanceObject, byOwnerName>(claim.account);
+   context.mutable_db.modify(liquidBalance, [&claim](BalanceObject& a) {
+      a.balance += claim.amount;
    });
 }
 

--- a/libraries/native_contract/include/eos/native_contract/staked_balance_objects.hpp
+++ b/libraries/native_contract/include/eos/native_contract/staked_balance_objects.hpp
@@ -74,6 +74,15 @@ class StakedBalanceObject : public chainbase::object<chain::staked_balance_objec
     * updating vote tallies
     */
    void beginUnstakingTokens(types::ShareType amount, chainbase::database& db) const;
+   /**
+    * @brief Finish unstaking the specified amount of stake
+    * @param amount The amount of stake to finish unstaking
+    * @param db Read-write reference to the database
+    *
+    * This method will update this object's balances. There aren't really any invariants to maintain on this call, as
+    * the tokens are already unstaked and removed from vote tallies, but it is provided for completeness' sake.
+    */
+   void finishUnstakingTokens(types::ShareType amount, chainbase::database& db) const;
 
    /**
     * @brief Propagate the specified change in stake to the producer votes or the proxy

--- a/libraries/native_contract/staked_balance_objects.cpp
+++ b/libraries/native_contract/staked_balance_objects.cpp
@@ -32,6 +32,12 @@ void StakedBalanceObject::beginUnstakingTokens(ShareType amount, chainbase::data
    });
 }
 
+void StakedBalanceObject::finishUnstakingTokens(ShareType amount, chainbase::database& db) const {
+   db.modify(*this, [&amount](StakedBalanceObject& sbo) {
+      sbo.unstakingBalance -= amount;
+   });
+}
+
 void StakedBalanceObject::propagateVotes(ShareType stakeDelta, chainbase::database& db) const {
    if (producerVotes.contains<ProducerSlate>())
       // This account votes for producers directly; update their stakes


### PR DESCRIPTION
The apply_staked_claim function appears to be defunct, a leftover of a
bygone era. It's logic, however, was not included in the still-active
apply_eos_claim, and that is a problem.

Move that missing logic into apply_eos_claim, pretty it up a bit, and
get rid of the vestigial apply_staked_claim.